### PR TITLE
Resolve trackApi with rejected attribute

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -47,11 +47,11 @@ This action handles the whole life cycle of an api request.
 This function also handles checking if the given ref is already pending, or has recently been called and will bail out if so.
 
 The steps this actions takes looks like
-1. Check if ref is currently pending, bail out if it is
-2. Check if ref has is within the specified cache time, bail out if it is
+1. Check if ref is currently pending, trackApi will resolve with `{ rejected: true }`
+2. Check if ref has is within the specified cache time, trackApi will resolve with `{ rejected: true }`
 3. Dispatch begin
-4.  If promise is rejected, dispatches failure with the error's message
+4.  If promise is rejected, dispatches failure with the error's message, trackApi will resolve with the error's message `{ error: error.message }`
     
     OR
     
-    If promise resolves, dispatches success with the response as the payload
+    If promise resolves, dispatches success with the response as the payload, trackApi will resolve with the response `{ response: response }`

--- a/src/actions.js
+++ b/src/actions.js
@@ -24,13 +24,15 @@ export const trackApi = (ref, promise, options = {}) => (dispatch, getState) => 
   const state = getStatus(getState())
 
   if (selectors.getIsPending(state, ref)) {
-    res({})
+    promise.catch(() => undefined)
+    res({ rejected: true })
     return
   }
 
   const cacheTime = options.cacheTime || 30000 // 30 seconds
   if (options.cacheTime !== false && Date.now() - selectors.getTimestamp(state, ref) < cacheTime) {
-    res({})
+    promise.catch(() => undefined)
+    res({ rejected: true })
     return
   }
 


### PR DESCRIPTION
### Description
At the moment `trackApi` throws an unresolved promise error when an api call is already being made, or has already been recently called.
There was also no previous way to differentiate between a failed/successful call and a rejected due to caching/rate limiting.

This PR resolves the issues.
https://github.com/zendesk/redux-api-status/issues/2
https://github.com/zendesk/redux-api-status/issues/1

