### PR TITLE
Allow getPromise function to return a thunk

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -74,6 +74,20 @@ import { connect } from 'react-redux'
 connect((state, props) => ({
   isPending: statusSelectors.getIsPending(state, fetchCat.getKey(props.catId))
 })
-
 ```
 
+`trackStatus`'s `getPromise` arugment can also return another function that will act kinda like a thunk.
+
+*Example*
+```js
+const fetchCat = trackStatus(
+  id => `CAT/FETCH/${id}`,
+  id => async (dispatch, getState) => {
+    if (selectors.getShouldOnlyFetchDogs(getState())) {
+      throw new Error('Only allowed to fetch dogs') 
+    }
+    
+    return api.getCat(id)
+  }
+)
+```

--- a/src/actions/track-status.js
+++ b/src/actions/track-status.js
@@ -23,7 +23,10 @@ const trackStatus = (getKey, getPromise, options = {}) => {
 
     dispatch(begin(key))
 
-    getPromise(...args)
+    const maybePromise = getPromise(...args)
+    const promise = typeof maybePromise === 'function' ? maybePromise(dispatch, getState) : maybePromise
+
+    promise
       .then(response => {
         dispatch(success(key, response))
 

--- a/src/actions/track-status.test.js
+++ b/src/actions/track-status.test.js
@@ -23,6 +23,21 @@ describe('trackStatus', () => {
       expect(typeof result === 'function')
     })
 
+    describe('when function returns another function', () => {
+      it('it is called as a thunk', async () => {
+        const dispatch = jest.fn()
+        const getState = jest.fn()
+        const arg = jest.fn()
+
+        const action = trackStatus('something', arg => async (dispatch, getState) => ({arg, dispatch, getState}))
+
+        const result = await action(arg)(dispatch, getState)
+
+        expect(result)
+          .toEqual({response: {arg, dispatch, getState}})
+      })
+    })
+
     describe('when pending', () => {
       let result
 


### PR DESCRIPTION
### Description
Since introducing the `trackStatus` function, it has been harder to track async actions that also need to access state and potentially dispatch more actions.

This PR allows the `getPromise` argument to return another function that will act like a thunk.

### Example
```js
const fetchCat = trackStatus(
  id => `CAT/FETCH/${id}`,
  id => async (dispatch, getState) => {
    if (selectors.getShouldOnlyFetchDogs(getState())) { 
      throw new Error('Only allowed to fetch dogs') 
    }
    
    return api.getCat(id)
  }
)
```